### PR TITLE
Simple scripts for importing / exporting IMTs and Licenses

### DIFF
--- a/sql/00-common-schema.sql
+++ b/sql/00-common-schema.sql
@@ -202,8 +202,8 @@ FSS	CF	d_fss:m	Storm surge inundation depth	m
 DTA	DR	CMI:-	Crop Moisture Index	-
 DTM	DR	PDSI:-	Palmer Drought Severity Index	-
 DTM	DR	SPI:-	Standard Precipitation Index	-
-LSL	LS	LSI:-	-	Landslide susceptibility index
-LSL	LS	haz_lsl:-	-	Landslide hazard index
+LSL	LS	LSI:-	Landslide susceptibility index	-
+LSL	LS	haz_lsl:-	Landslide hazard index	-
 \.
 
 

--- a/sql/00-common-schema.sql
+++ b/sql/00-common-schema.sql
@@ -202,6 +202,8 @@ FSS	CF	d_fss:m	Storm surge inundation depth	m
 DTA	DR	CMI:-	Crop Moisture Index	-
 DTM	DR	PDSI:-	Palmer Drought Severity Index	-
 DTM	DR	SPI:-	Standard Precipitation Index	-
+LSL	LS	LSI:-	-	Landslide susceptibility index
+LSL	LS	haz_lsl:-	-	Landslide hazard index
 \.
 
 
@@ -312,4 +314,3 @@ ALTER TABLE ONLY cf_common.process_type
 --
 -- PostgreSQL database dump complete
 --
-

--- a/sql/export-imt.sh
+++ b/sql/export-imt.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. $(readlink -f $(dirname $0))/db_settings.sh
+
+psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d $DB_NAME \
+	-c 'COPY (SELECT * FROM cf_common.imt ORDER BY hazard_code, process_code) TO STDOUT WITH (FORMAT CSV, HEADER)'

--- a/sql/export-license.sh
+++ b/sql/export-license.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. $(readlink -f $(dirname $0))/db_settings.sh
+
+psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d $DB_NAME -c \
+ 'COPY (SELECT * FROM cf_common.license ORDER BY code) TO STDOUT WITH (FORMAT CSV, HEADER)'

--- a/sql/import-imt.sh
+++ b/sql/import-imt.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ $# -ne 1 ]
+then
+	echo "Usage: $0 <imt csv file (with headers)>"
+	exit 1
+fi
+
+INFILE=$1
+if [ ! -r "$INFILE" ]
+then
+	echo "$0: Unable to open $INFILE for reading"
+	exit 1
+fi
+
+. $(readlink -f $(dirname $0))/db_settings.sh
+
+cat $INFILE | \
+psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d $DB_NAME \
+	-c 'COPY cf_common.imt FROM STDIN WITH (FORMAT CSV, HEADER)'

--- a/sql/import-license.sh
+++ b/sql/import-license.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ $# -ne 1 ]
+then
+	echo "Usage: $0 <license csv file (with headers)>"
+	exit 1
+fi
+
+INFILE=$1
+if [ ! -r "$INFILE" ]
+then
+	echo "$0: Unable to open $INFILE for reading"
+	exit 1
+fi
+
+. $(readlink -f $(dirname $0))/db_settings.sh
+
+cat $INFILE | \
+psql -U $DB_USER -h $DB_HOST -p $DB_PORT -d $DB_NAME \
+	-c 'COPY cf_common.license FROM STDIN WITH (FORMAT CSV, HEADER)'


### PR DESCRIPTION
Simple Shell scripts to import and export IMTs and licenses in the CSV format.
